### PR TITLE
Code of Conduct: Added subsection headings for readability

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,12 +1,18 @@
 # E4S Contributor Code of Conduct
 
+## Our Pledge
+
 As contributors and maintainers of this project, and in the interest of
 fostering an open and welcoming community, we pledge to respect all people who
 contribute through reporting issues, posting feature requests, updating
 documentation, submitting pull requests or patches, and other activities.
 
+## Our Standards
+
 We are committed to making participation in this project a harassment-free
 experience for everyone.
+
+## Our Responsibilities
 
 Project maintainers have the right and responsibility to remove, edit, or
 reject comments, commits, code, wiki edits, issues, and other contributions
@@ -19,8 +25,12 @@ fairly and consistently applying these principles to every aspect of managing
 this project. Project maintainers who do not follow or enforce the Code of
 Conduct may be permanently removed from the project team.
 
+## Scope
+
 This Code of Conduct applies both within project spaces and in public spaces
 when an individual is representing the project or its community.
+
+## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported by contacting an [E4S Technical Steering Committee Member](https://github.com/E4S-Project/governance/blob/main/GOVERNANCE.md). All
@@ -29,6 +39,7 @@ is deemed necessary and appropriate to the circumstances. Maintainers are
 obligated to maintain confidentiality with regard to the reporter of an
 incident.
 
+## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 1.3.0, available at https://www.contributor-covenant.org/version/1/3/0/code-of-conduct.html


### PR DESCRIPTION
@jwillenbring 

This PR add subsection headings that were introduced in Contributor Covenant v1.4 to improve readability (especially for those who are in a hurry and just want to find specific content).